### PR TITLE
Add a toggle for terminal resize signal handling

### DIFF
--- a/include/teye/teye.h
+++ b/include/teye/teye.h
@@ -23,6 +23,9 @@ extern "C" {
 
 #define pixelcount(buffer) (buffer.width * buffer.height)
 
+// These can be passed as flags to the library at initialization
+#define HANDLE_RESIZE 1
+
 // Drawing modes
 typedef enum { FitWidth, FitHeight, Stretch, FitBest } ScalingMode;
 // Intended feature implementation
@@ -55,15 +58,16 @@ typedef struct {
 } TEYE_Buffer;
 
 /** Initialize the terminal and the framebuffers */
-int TEYE_init();
+int TEYE_init(int flags);
 
-/* NON-IMPLEMENTED!
+/*
  * Gives Teye a callback that will be called on window resize events. That
  * function has to be of the type `TEYE_ResizeCallback`.
- * It should take as arguments the new size of the rendering window and return a
- * flag number dictating how the event will be handled. Each bit of the flag
- * control one particular behaviour. Please refer to the macros for more
- * information.*/
+ * information.
+ *
+ * @note The callback should return 0 if the terminal should be cleared and -1
+ * otherwise.
+ */
 void TEYE_set_resize_callback(TEYE_ResizeCallback callback);
 
 /*

--- a/src/teye_core.c
+++ b/src/teye_core.c
@@ -41,7 +41,9 @@ See the LICENCE section for details.
  Global variables
  ****************/
 
-// Nothing to see there, just a classic lookup table
+/** Nothing to see there, just a classic lookup table
+ @note: This should be moved elsewhere
+ */
 static char colors[][5] = {
     "0m",   "1m",   "2m",   "3m",   "4m",   "5m",   "6m",   "7m",   "8m",
     "9m",   "10m",  "11m",  "12m",  "13m",  "14m",  "15m",  "16m",  "17m",
@@ -85,6 +87,9 @@ static TEYE_Buffer back_framebuffer;
 static struct CharBuffer char_buffer;
 
 static TEYE_ResizeCallback resize_callback = NULL;
+
+/** This flag controls whether Teye should listen for the SIGWINCH signal */
+static int handle_terminal_resize = 0;
 
 /****************
  Functions
@@ -137,7 +142,11 @@ clear:
   TEYE_clear_buffer(back_framebuffer, 0);
 }
 
-int TEYE_init() {
+int TEYE_init(int flags) {
+
+  if ((flags & HANDLE_RESIZE) != 0) {
+    handle_terminal_resize = 1;
+  }
 
   printf("\x1b[?1049h"); // Switch to alternate buffer
 
@@ -183,7 +192,9 @@ void TEYE_blit(TEYE_Buffer src, ScalingMode mode, int x, int y) {
 
 void TEYE_render_frame() {
 
-  signal(SIGWINCH, signalHandler);
+  if (handle_terminal_resize) {
+    signal(SIGWINCH, signalHandler);
+  }
 
   // if (size_changed) {
   //   // the back buffer is now misleading, clean it
@@ -280,20 +291,21 @@ void TEYE_render_frame() {
     }
   } while (1);
 
-  if (screen_resized == 1) {
+  if (screen_resized != 0 && handle_terminal_resize != 0) {
 
     // The screen was resized, we need to reallocate the framebuffers
     reset_frame_buffers();
     screen_resized = 0;
 
-    // TODO: take into account the return value of the function
     if (resize_callback != NULL) {
       int code =
           resize_callback(front_framebuffer.width, front_framebuffer.height);
-    }
 
-    move_cursor_top_left();
-    clear_screen();
+      if (code == 0) {
+        move_cursor_top_left();
+        clear_screen();
+      }
+    }
   }
 
   write(STDOUT_FILENO, char_buffer.buf, char_buffer.len);

--- a/tests/bounce.c
+++ b/tests/bounce.c
@@ -40,7 +40,7 @@ int main() {
   TEYE_Buffer buffer = {0};
 
   // Initialize the library
-  if (TEYE_init() != 0) {
+  if (TEYE_init(0) != 0) {
     perror("Couldn't initialize Teye");
     return -1;
   }

--- a/tests/mandelbrot.c
+++ b/tests/mandelbrot.c
@@ -47,7 +47,7 @@ int main() {
   TEYE_Buffer buffer = {0};
 
   // Initialize the library
-  if (TEYE_init() != 0) {
+  if (TEYE_init(HANDLE_RESIZE) != 0) {
     perror("Couldn:t initialize Teye");
     return -1;
   }


### PR DESCRIPTION
Up to now,  Teye automatically resize the viewport when the terminal's size changes. This commit adds a toggle to let the user decide whether they want that feature or not.